### PR TITLE
Don't decode non-string values

### DIFF
--- a/odbc/statement.inc
+++ b/odbc/statement.inc
@@ -217,8 +217,10 @@ class DatabaseStatement_odbc extends DatabaseStatementPrefetch implements Iterat
 		foreach ($rows as $row) {
 			$decoded_row = array();
 			foreach ($row as $key => $value) {
-				$decoded_value = unicode_x_decode($value);
-				$decoded_row[$key] = $decoded_value;
+				if (is_string($value)) {
+					$decoded_value = unicode_x_decode($value);
+					$decoded_row[$key] = $decoded_value;
+				}
 			}
 			$decoded_rows[] = $decoded_row;
 		}


### PR DESCRIPTION
## Because

Not all values can safely be treated as strings. In particular, NULL is broken by being treated as a string, coming out as an empty string instead.

## This change

Checks each value's type in `DatabaseStatement_odbc::decodeData()` before running `unicode_x_decode`.